### PR TITLE
Improve planet spawning logic to prevent overlapping and overcrowding

### DIFF
--- a/core/src/se/yrgo/game/GameScreen.java
+++ b/core/src/se/yrgo/game/GameScreen.java
@@ -17,14 +17,13 @@ import com.badlogic.gdx.utils.ScreenUtils;
  * Implements {@link InputProcessor} to handle user input.
  */
 public class GameScreen extends ScreenAdapter implements InputProcessor {
-	private static final int ALIEN_WIDTH = 106;
-	private static final int ALIEN_HEIGHT = 80;
-	private static final float SPEED_START = 50;
+    private static final int ALIEN_WIDTH = 106;
+    private static final int ALIEN_HEIGHT = 80;
+    private static final float SPEED_START = 50;
 
     private AlienGame alienGame;
     private SpriteBatch batch;
     private AnimatedSprite alien;
-    private Texture planetTexture;
     private List<AnimatedSprite> planets;
     private boolean gameOver = false;
     private float elapsedTime;
@@ -32,11 +31,15 @@ public class GameScreen extends ScreenAdapter implements InputProcessor {
 
     private String[] planetsArr = { "bloodMoon.png", "earth.png", "jupiter.png", "mars.png", "moon.png", "venus.png" };
 
-
     // Gravity and bounce mechanics
     private static final float GRAVITY = -600f; // Gravity affecting the ship
     private static final float BOUNCE_VELOCITY = 400f; // Velocity applied on spacebar press
     private boolean isFirstInput = true; // Prevents gravity before first input
+
+    // Planet spawning control
+    private float planetSpawnTimer = 0;
+    private static final float PLANET_SPAWN_INTERVAL = 1.5f; // Time between planet spawns (in seconds)
+    private static final int MAX_PLANETS_ON_SCREEN = 5; // Maximum number of planets allowed on screen
 
     /**
      * Constructor for the GameScreen.
@@ -50,26 +53,80 @@ public class GameScreen extends ScreenAdapter implements InputProcessor {
         this.planets = new ArrayList<>();
     }
 
-    	/**
-	 * get random planet image url, based on planetsArr
-	 * 
-	 * @return String image path of a random planet
-	 */
-	private String randomizePlanet() {
-		Random random = new Random();
-		int randomPlanetIndex = random.nextInt(planetsArr.length);
-		String randomPlanet = planetsArr[randomPlanetIndex];
+    /**
+     * Get random planet image URL, based on planetsArr.
+     *
+     * @return String image path of a random planet.
+     */
+    private String randomizePlanet() {
+        Random random = new Random();
+        int randomPlanetIndex = random.nextInt(planetsArr.length);
+        return planetsArr[randomPlanetIndex];
+    }
 
-		return randomPlanet;
-	}
+    /**
+     * Adds a planet at a random position, ensuring it doesn't overlap with existing planets.
+     */
+    private void addPlanet() {
+        int screenWidth = Gdx.graphics.getWidth();
+        int screenHeight = Gdx.graphics.getHeight();
+        int minDistance = 400; // Minimum distance between planets (adjust as needed)
+        int maxAttempts = 100; // Maximum attempts to find a valid position
+        int attempts = 0;
+
+        int x, y;
+        boolean positionValid;
+
+        do {
+            // Randomize X and Y coordinates
+            x = ThreadLocalRandom.current().nextInt(screenWidth / 2, screenWidth); // Spawn planets on the right side
+            y = ThreadLocalRandom.current().nextInt(0, screenHeight - ALIEN_HEIGHT);
+
+            positionValid = true;
+
+            // Check if the new planet overlaps with any existing planet
+            for (AnimatedSprite planet : planets) {
+                float distanceX = Math.abs(planet.getX() - x);
+                float distanceY = Math.abs(planet.getY() - y);
+
+                // Check if the distance is too small in either X or Y direction
+                if (distanceX < minDistance && distanceY < minDistance) {
+                    positionValid = false;
+                    break;
+                }
+            }
+
+            attempts++;
+        } while (!positionValid && attempts < maxAttempts);
+
+        if (positionValid) {
+            addPlanet(x, y);
+        } else {
+            // If no valid position is found after maxAttempts, skip adding this planet
+            return;
+        }
+    }
+
+    /**
+     * Creates a planet sprite at the specified coordinates and adds it to the list.
+     *
+     * @param x The X-coordinate of the planet.
+     * @param y The Y-coordinate of the planet.
+     */
+    private void addPlanet(int x, int y) {
+        String planetTexturePath = randomizePlanet();
+        Texture planetTexture = new Texture(planetTexturePath);
+
+        AnimatedSprite planet = new AnimatedSprite(planetTexture, x, y, planetTexture.getWidth(), planetTexture.getHeight());
+        planet.setDeltaX(-speed); // Move the planet to the left
+        planets.add(planet);
+    }
 
     /** Called when this screen is hidden. Removes the input processor. */
     @Override
     public void hide() {
         Gdx.input.setInputProcessor(null);
     }
-
-
 
     /**
      * Initializes the game screen when it is displayed.
@@ -80,55 +137,22 @@ public class GameScreen extends ScreenAdapter implements InputProcessor {
         final int width = Gdx.graphics.getWidth();
         final int height = Gdx.graphics.getHeight();
 
-		elapsedTime = 0;
-		speed = SPEED_START;
-		gameOver = false;
+        elapsedTime = 0;
+        speed = SPEED_START;
+        gameOver = false;
 
         alien.setBounds(new Rectangle(0, 0, width / 2f, height));
         alien.setPosition(100, height / 2 - ALIEN_HEIGHT / 2);
-
 
         // Reset vertical movement and first input flag
         alien.setDeltaY(0);
         isFirstInput = true;
 
-		planets.clear();
-		for (int i = 0; i < 10; ++i) {
-			addPlanet(width / 4 + i * 100);
-			speed += 1.3;
-		}
+        planets.clear();
+        planetSpawnTimer = 0; // Reset the planet spawn timer
 
         Gdx.input.setInputProcessor(this);
     }
-
-
-    /**
-     * Adds an planet at a random Y-coordinate.
-     *
-     * @param x The X-coordinate where the planet should be placed.
-     */
-	private void addPlanet(int x) {
-		int range = Gdx.graphics.getHeight() - ALIEN_HEIGHT;
-		int y = ThreadLocalRandom.current().nextInt(range);
-		addPlanet(x, y);
-	}
-
-    
-    /**
-     * Creates an planet sprite at the specified coordinates and adds it to the list.
-     *
-     * @param x The X-coordinate of the alien.
-     * @param y The Y-coordinate of the alien.
-     */
-	private void addPlanet(int x, int y) {
-		String planettexturePath = randomizePlanet();
-		this.planetTexture = new Texture(planettexturePath);
-
-		AnimatedSprite planet = new AnimatedSprite(planetTexture, x, y, planetTexture.getWidth(),
-				planetTexture.getHeight());
-		planet.setDeltaX(-speed);
-		planets.add(planet);
-	}
 
     /**
      * Renders the game screen.
@@ -136,12 +160,19 @@ public class GameScreen extends ScreenAdapter implements InputProcessor {
      * @param deltaTime The time elapsed since the last frame.
      */
     @Override
-	public void render(float deltaTime) {
-		if (gameOver) {
-			return;
-		}
+    public void render(float deltaTime) {
+        if (gameOver) {
+            return;
+        }
 
         elapsedTime += deltaTime;
+        planetSpawnTimer += deltaTime;
+
+        // Spawn a new planet if enough time has passed and there are not too many planets on screen
+        if (planetSpawnTimer >= PLANET_SPAWN_INTERVAL && planets.size() < MAX_PLANETS_ON_SCREEN) {
+            addPlanet();
+            planetSpawnTimer = 0; // Reset the timer
+        }
 
         updateState(deltaTime);
         renderScreen();
@@ -166,27 +197,26 @@ public class GameScreen extends ScreenAdapter implements InputProcessor {
 
         // Update aliens and remove any that go off-screen
         List<AnimatedSprite> toRemove = new ArrayList<>();
-		for (AnimatedSprite planet : planets) {
-			planet.update(deltaTime);
-			if (planet.getX() < -planetTexture.getWidth()) {
-				toRemove.add(planet);
-			}
-		}
+        for (AnimatedSprite planet : planets) {
+            planet.update(deltaTime);
+            if (planet.getX() < -planet.getWidth()) {
+                toRemove.add(planet);
+            }
+        }
 
-		planets.removeAll(toRemove);
-		for (AnimatedSprite planet : toRemove) {
-			planet.dispose();
-			addPlanet(Gdx.graphics.getWidth() + planetTexture.getWidth());
-		}
+        planets.removeAll(toRemove);
+        for (AnimatedSprite planet : toRemove) {
+            planet.dispose();
+        }
 
-		alienGame.addPoints((int) (toRemove.size() * speed));
-	}
+        alienGame.addPoints((int) (toRemove.size() * speed));
+    }
 
-      /** Clears the screen and renders all sprites. */
-	private void renderScreen() {
-		// set blue background color
-		Gdx.gl.glClearColor(0.043f, 0.078f, 0.22f, 1.0f);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+    /** Clears the screen and renders all sprites. */
+    private void renderScreen() {
+        // Set blue background color
+        Gdx.gl.glClearColor(0.043f, 0.078f, 0.22f, 1.0f);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
         batch.begin();
         alien.draw(batch, elapsedTime);
@@ -201,10 +231,10 @@ public class GameScreen extends ScreenAdapter implements InputProcessor {
     /** Checks for collisions between the ship and aliens or the ground. */
     private void checkForGameOver() {
         for (AnimatedSprite planet : planets) {
-			if (planet.overlaps(alien)) {
-				gameOver = true;
-			}
-		}
+            if (planet.overlaps(alien)) {
+                gameOver = true;
+            }
+        }
 
         if (alien.getY() <= 0) {
             gameOver = true;
@@ -213,19 +243,17 @@ public class GameScreen extends ScreenAdapter implements InputProcessor {
         if (alien.getY() + alien.getHeight() >= Gdx.graphics.getHeight()) {
             gameOver = true;
         }
-
     }
 
     /** Disposes of all allocated resources when the screen is no longer needed. */
     @Override
-	public void dispose() {
-		batch.dispose();
-		alien.dispose();
-		planetTexture.dispose();
-		for (AnimatedSprite planet : planets) {
-			planet.dispose();
-		}
-	}
+    public void dispose() {
+        batch.dispose();
+        alien.dispose();
+        for (AnimatedSprite planet : planets) {
+            planet.dispose();
+        }
+    }
 
     /**
      * Handles key press events. The SPACE key makes the ship bounce upwards.
@@ -269,15 +297,14 @@ public class GameScreen extends ScreenAdapter implements InputProcessor {
         return false;
     }
 
-
-	@Override
-	public boolean scrolled(float amountX, float amountY) {
-		return false;
-	}
+    @Override
+    public boolean scrolled(float amountX, float amountY) {
+        return false;
+    }
 
     @Override
     public boolean touchCancelled(int screenX, int screenY, int pointer, int button) {
-       return false;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
- Increased `minDistance` to 400 to ensure planets are spaced farther apart.
- Added `PLANET_SPAWN_INTERVAL` (1.5 seconds) to control the frequency of planet spawning.
- Introduced `MAX_PLANETS_ON_SCREEN` (5 planets) to limit the number of planets on the screen at once.
- Updated `addPlanet` method to dynamically place planets with proper spacing.
