### PR TITLE
Change difficulty system to vary by planet count instead of speed

### DIFF
--- a/core/src/se/yrgo/game/GameScreen.java
+++ b/core/src/se/yrgo/game/GameScreen.java
@@ -15,17 +15,27 @@ public class GameScreen extends ScreenAdapter implements InputProcessor {
     private static final int ALIEN_HEIGHT = 100;
 
     // Difficulty-based constants
-    private static final float EASY_SPEED_START = 100f;
-    private static final float MEDIUM_SPEED_START = 130f;
-    private static final float HARD_SPEED_START = 170f;
+//    private static final float MEDIUM_SPEED_START = 130f;
+//    private static final float HARD_SPEED_START = 170f;
+//
+//    private static final float EASY_PLANET_SPAWN_INTERVAL = 2.0f;
+//    private static final float MEDIUM_PLANET_SPAWN_INTERVAL = 1.5f;
+//    private static final float HARD_PLANET_SPAWN_INTERVAL = 1.0f;
+//
+//    private static final int EASY_MAX_PLANETS = 4;
+//    private static final int MEDIUM_MAX_PLANETS = 5;
+//    private static final int HARD_MAX_PLANETS = 6;
 
-    private static final float EASY_PLANET_SPAWN_INTERVAL = 2.0f;
-    private static final float MEDIUM_PLANET_SPAWN_INTERVAL = 1.5f;
+    // Same speed for all difficulties
+    private static final float PLANET_SPEED = 130f;
+    private static final float EASY_PLANET_SPAWN_INTERVAL = 3.0f;
+    private static final float MEDIUM_PLANET_SPAWN_INTERVAL = 2.0f;
     private static final float HARD_PLANET_SPAWN_INTERVAL = 1.0f;
 
-    private static final int EASY_MAX_PLANETS = 4;
+    // Max planets allowed on screen per difficulty
+    private static final int EASY_MAX_PLANETS = 3;
     private static final int MEDIUM_MAX_PLANETS = 5;
-    private static final int HARD_MAX_PLANETS = 6;
+    private static final int HARD_MAX_PLANETS = 7;
 
     private AlienGame alienGame;
     private SpriteBatch batch;
@@ -138,7 +148,7 @@ public class GameScreen extends ScreenAdapter implements InputProcessor {
 
         AnimatedSprite planet = new AnimatedSprite(planetTexture, x, y, planetTexture.getWidth(),
                 planetTexture.getHeight());
-        planet.setDeltaX(-speed);
+        planet.setDeltaX(-PLANET_SPEED);
         planets.add(planet);
     }
 
@@ -158,17 +168,14 @@ public class GameScreen extends ScreenAdapter implements InputProcessor {
         // Set difficulty-based parameters
         switch (alienGame.getDifficulty()) {
             case EASY:
-                speed = EASY_SPEED_START;
                 PLANET_SPAWN_INTERVAL = EASY_PLANET_SPAWN_INTERVAL;
                 MAX_PLANETS_ON_SCREEN = EASY_MAX_PLANETS;
                 break;
             case MEDIUM:
-                speed = MEDIUM_SPEED_START;
                 PLANET_SPAWN_INTERVAL = MEDIUM_PLANET_SPAWN_INTERVAL;
                 MAX_PLANETS_ON_SCREEN = MEDIUM_MAX_PLANETS;
                 break;
             case HARD:
-                speed = HARD_SPEED_START;
                 PLANET_SPAWN_INTERVAL = HARD_PLANET_SPAWN_INTERVAL;
                 MAX_PLANETS_ON_SCREEN = HARD_MAX_PLANETS;
                 break;
@@ -213,8 +220,6 @@ public class GameScreen extends ScreenAdapter implements InputProcessor {
         if (!isFirstInput) {
             alien.setDeltaY(alien.getDeltaY() + GRAVITY * deltaTime);
         }
-
-        speed += 20 * deltaTime;
 
         // When falling, revert to the normal texture.
         if (alien.getDeltaY() <= 0) {


### PR DESCRIPTION
refactor: Change difficulty system to vary by planet count instead of speed

- Removed speed variations between difficulty levels (now uses constant PLANET_SPEED)
- Difficulty now affects:
  - Number of planets on screen (3 for Easy, 5 for Medium, 7 for Hard)
  - Planet spawn frequency (3s for Easy, 2s for Medium, 1s for Hard)
- Removed speed increase over time mechanic
- Updated all related constants in GameScreen.java
- Adjusted planet spawning logic to use new difficulty parameters

This change makes the game more about managing multiple obstacles rather than dealing with increasing speed, creating a different kind of challenge for players.